### PR TITLE
Fixed scope and tiling isssues in exquis-bac-a-sable

### DIFF
--- a/exquis-bac-a-sable/exquisite-conductor.html
+++ b/exquis-bac-a-sable/exquisite-conductor.html
@@ -3,8 +3,12 @@
   <html>
     <head>
       <meta charset="UTF-8" />
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.5.0/p5.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.11/addons/p5.dom.min.js"></script>
+      <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.2/p5.min.js"
+        integrity="sha512-1YMgn4j8cIL91s14ByDGmHtBU6+F8bWOMcF47S0cRO3QNm8SKPNexy4s3OCim9fABUtO++nJMtcpWbINWjMSzQ=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
+      ></script>
       <script src="https://unpkg.com/p5.js-svg@1.5.1"></script>
       <style>
         body {

--- a/exquis-bac-a-sable/exquisite-conductor.html
+++ b/exquis-bac-a-sable/exquisite-conductor.html
@@ -1,49 +1,47 @@
 <!doctype html>
 <html lang="en">
-  <html>
-    <head>
-      <meta charset="UTF-8" />
-      <script
-        src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.2/p5.min.js"
-        integrity="sha512-1YMgn4j8cIL91s14ByDGmHtBU6+F8bWOMcF47S0cRO3QNm8SKPNexy4s3OCim9fABUtO++nJMtcpWbINWjMSzQ=="
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer"
-      ></script>
-      <script src="https://unpkg.com/p5.js-svg@1.5.1"></script>
-      <style>
-        body {
-          padding: 0;
-          margin: 0;
-          background-color: black;
-        }
-      </style>
-    </head>
+  <head>
+    <meta charset="UTF-8" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.2/p5.min.js"
+      integrity="sha512-1YMgn4j8cIL91s14ByDGmHtBU6+F8bWOMcF47S0cRO3QNm8SKPNexy4s3OCim9fABUtO++nJMtcpWbINWjMSzQ=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
+    <script src="https://unpkg.com/p5.js-svg@1.5.1"></script>
+    <!-- <script type="module" src="./hello-wasm/pkg/hello_wasm.js"></script> -->
+    <style>
+      body {
+        padding: 0;
+        margin: 0;
+        background-color: black;
+      }
+    </style>
+  </head>
 
-    <body>
-      <script src="exquisite-conductor.js"></script>
-      <script>
-        function fetchJSONData() {
-          fetch("./exquisite.json")
-            .then((response) => {
-              if (!response.ok) {
-                throw new Error(`HTTP error! Status: ${response.status}`);
-              }
-              return response.json();
-            })
-            .then((data) => {
-              //for each object in the configuration , get the sketch name and add the sketch file to the current document
-              for (const s of data) {
-                var js = document.createElement("script");
-                js.type = "text/javascript";
-                js.src = "./" + s.art_code;
-                document.body.appendChild(js);
-              }
-            })
-            .catch((error) => console.error("Failed to fetch data:", error));
-        }
-        fetchJSONData();
-      </script>
-    </body>
-  </html>
+  <body>
+    <script src="exquisite-conductor.js"></script>
+    <script>
+      function fetchJSONData() {
+        fetch("./exquisite.json")
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`HTTP error! Status: ${response.status}`);
+            }
+            return response.json();
+          })
+          .then((data) => {
+            //for each object in the configuration , get the sketch name and add the sketch file to the current document
+            for (const s of data) {
+              var js = document.createElement("script");
+              js.type = "text/javascript";
+              js.src = "./" + s.art_code;
+              document.body.appendChild(js);
+            }
+          })
+          .catch((error) => console.error("Failed to fetch data:", error));
+      }
+      fetchJSONData();
+    </script>
+  </body>
 </html>
-

--- a/exquis-bac-a-sable/exquisite-conductor.html
+++ b/exquis-bac-a-sable/exquisite-conductor.html
@@ -9,7 +9,6 @@
       referrerpolicy="no-referrer"
     ></script>
     <script src="https://unpkg.com/p5.js-svg@1.5.1"></script>
-    <!-- <script type="module" src="./hello-wasm/pkg/hello_wasm.js"></script> -->
     <style>
       body {
         padding: 0;

--- a/exquis-bac-a-sable/exquisite-conductor.html
+++ b/exquis-bac-a-sable/exquisite-conductor.html
@@ -35,7 +35,7 @@
             for (const s of data) {
               var js = document.createElement("script");
               js.type = "text/javascript";
-              js.src = "./" + s.art_code;
+              js.src = "./" + s.art_code + ".js";
               document.body.appendChild(js);
             }
           })

--- a/exquis-bac-a-sable/exquisite-conductor.html
+++ b/exquis-bac-a-sable/exquisite-conductor.html
@@ -33,7 +33,7 @@
             //for each object in the configuration , get the sketch name and add the sketch file to the current document
             for (const s of data) {
               var js = document.createElement("script");
-              js.type = "text/javascript";
+              js.type = "module";
               js.src = "./" + s.art_code + ".js";
               document.body.appendChild(js);
             }

--- a/exquis-bac-a-sable/exquisite-conductor.html
+++ b/exquis-bac-a-sable/exquisite-conductor.html
@@ -1,45 +1,45 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<html>
-
-<head>
-    <meta charset="UTF-8">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.5.0/p5.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.11/addons/p5.dom.min.js"></script>
-    <script src="https://unpkg.com/p5.js-svg@1.5.1"></script>
-    <style>
+  <html>
+    <head>
+      <meta charset="UTF-8" />
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.5.0/p5.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.11/addons/p5.dom.min.js"></script>
+      <script src="https://unpkg.com/p5.js-svg@1.5.1"></script>
+      <style>
         body {
-            padding: 0;
-            margin: 0;
-            background-color: black;
+          padding: 0;
+          margin: 0;
+          background-color: black;
         }
-    </style>
-</head>
+      </style>
+    </head>
 
-<body>
-    <script src="exquisite-conductor.js"></script>
-    <script>
+    <body>
+      <script src="exquisite-conductor.js"></script>
+      <script>
         function fetchJSONData() {
-            fetch('./exquisite.json')
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error(`HTTP error! Status: ${response.status}`);
-                    }
-                    return response.json()
-                })
-                .then(data => {
-                    //for each object in the configuration , get the sketch name and add the sketch file to the current document
-                    for (const s of data) {
-                        var js = document.createElement("script");
-                        js.type = "text/javascript";
-                        js.src = "./" + s.art_code;
-                        document.body.appendChild(js)
-                    }
-                })
-                .catch(error => console.error('Failed to fetch data:', error));
+          fetch("./exquisite.json")
+            .then((response) => {
+              if (!response.ok) {
+                throw new Error(`HTTP error! Status: ${response.status}`);
+              }
+              return response.json();
+            })
+            .then((data) => {
+              //for each object in the configuration , get the sketch name and add the sketch file to the current document
+              for (const s of data) {
+                var js = document.createElement("script");
+                js.type = "text/javascript";
+                js.src = "./" + s.art_code;
+                document.body.appendChild(js);
+              }
+            })
+            .catch((error) => console.error("Failed to fetch data:", error));
         }
         fetchJSONData();
-    </script>
-</body>
-
+      </script>
+    </body>
+  </html>
 </html>
+

--- a/exquis-bac-a-sable/exquisite-conductor.html
+++ b/exquis-bac-a-sable/exquisite-conductor.html
@@ -3,8 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.2/p5.min.js"
-      integrity="sha512-1YMgn4j8cIL91s14ByDGmHtBU6+F8bWOMcF47S0cRO3QNm8SKPNexy4s3OCim9fABUtO++nJMtcpWbINWjMSzQ=="
+      src="https://cdn.jsdelivr.net/npm/p5@2.0.0-beta.4/lib/p5.min.js"
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
@@ -32,7 +31,7 @@
           .then((data) => {
             //for each object in the configuration , get the sketch name and add the sketch file to the current document
             for (const s of data) {
-              var js = document.createElement("script");
+              let js = document.createElement("script");
               js.type = "module";
               js.src = "./" + s.art_code + ".js";
               document.body.appendChild(js);

--- a/exquis-bac-a-sable/exquisite-conductor.js
+++ b/exquis-bac-a-sable/exquisite-conductor.js
@@ -1,120 +1,125 @@
 //global variable only used here in the orchestrator sketch
-var O_widthexquis, O_heightexquis, O_canvas, O_policeexquise, O_sections, O_nbsectionshorizontal, O_nbsectionsvertical, O_configurationexquise
+var O_widthexquis,
+  O_heightexquis,
+  O_canvas,
+  O_policeexquise,
+  O_sections,
+  O_nbsectionshorizontal,
+  O_nbsectionsvertical,
+  O_configurationexquise;
 //global variables that can be used in all sketches
-var O_sectionwidth //width of a section
-var O_sectionheight //height of a section
-var O_sectionduration //duration (in frames) for one section animation
-var O_currentsection //object that has data for the section that is currently drawing
-var O_counter = 0 //global frame counter
-
+var O_sectionwidth; //width of a section
+var O_sectionheight; //height of a section
+var O_sectionduration; //duration (in frames) for one section animation
+var O_currentsection; //object that has data for the section that is currently drawing
+var O_counter = 0; //global frame counter
 
 function preload() {
-    O_policeexquise = loadFont("./FreeMono.otf");
-    O_configurationexquise = loadJSON('./exquisite.json');
+  O_policeexquise = loadFont("./FreeMono.otf");
+  O_configurationexquise = loadJSON("./exquisite.json");
 }
 
 function setup() {
-    O_widthexquis = Math.floor(windowWidth * 0.8)
-    O_heightexquis = Math.floor(O_widthexquis / 1.82)
-    O_canvas = createCanvas(O_widthexquis, O_heightexquis);
-    O_nbsectionshorizontal = 1
-    O_nbsectionsvertical = 2
-    O_sectionduration = 60 * 2
+  O_widthexquis = Math.floor(windowWidth * 0.8);
+  O_heightexquis = Math.floor(O_widthexquis / 1.82);
+  O_canvas = createCanvas(O_widthexquis, O_heightexquis);
+  O_nbsectionshorizontal = 1;
+  O_nbsectionsvertical = 2;
+  O_sectionduration = 60 * 2;
 
-    // center the canvas
-    var x = (windowWidth - O_widthexquis) / 2;
-    var y = (windowHeight - O_heightexquis) / 2;
-    O_canvas.position(x, y);
-    colorMode(HSB, 360, 100, 100, 250);
+  // center the canvas
+  var x = (windowWidth - O_widthexquis) / 2;
+  var y = (windowHeight - O_heightexquis) / 2;
+  O_canvas.position(x, y);
+  colorMode(HSB, 360, 100, 100, 250);
 
-    // initialize all sections and shuffle their order
-    O_sectionwidth = Math.floor(O_widthexquis / O_nbsectionshorizontal)
-    O_sectionheight = Math.floor(O_heightexquis / O_nbsectionsvertical)
-    initsections()
-    O_sections = shuffle(O_sections)
-    textSize(84)
-    textFont(O_policeexquise)
-    stroke(0, 0, 100);
+  // initialize all sections and shuffle their order
+  O_sectionwidth = Math.floor(O_widthexquis / O_nbsectionshorizontal);
+  O_sectionheight = Math.floor(O_heightexquis / O_nbsectionsvertical);
+  initsections();
+  O_sections = shuffle(O_sections);
+  textSize(84);
+  textFont(O_policeexquise);
+  stroke(0, 0, 100);
 }
 
 function initsections() {
-    O_sections = []
-    var x1, y1, x2, y2, x3, y3, x4, y4, id
-    id=0
-    for (var i = 0; i < O_nbsectionshorizontal; i++) {
-        for (var j = 0; j < O_nbsectionsvertical; j++) {
-            if (i == 0) {
-                y4 = random(O_sectionheight * 0.1, O_sectionheight * 0.9)
-            }
-            else {
-                y4 = O_sections[(i - 1) * O_nbsectionsvertical + j].y2
-            }
-            if (j == 0) {
-                x1 = random(O_sectionwidth * 0.1, O_sectionwidth * 0.9)
-            }
-            else {
-                x1 = O_sections[i * O_nbsectionsvertical + (j - 1)].x3
-            }
-            var s = {
-                x: i * O_sectionwidth,
-                y: j * O_sectionheight,
-                x1: x1,
-                y1: 0,
-                x2: O_sectionwidth,
-                y2: random(O_sectionheight * 0.1, O_sectionheight * 0.9),
-                x3: random(O_sectionwidth * 0.1, O_sectionwidth * 0.9),
-                y3: O_sectionheight,
-                x4: 0,
-                y4: y4,
-                id:id
-            }
-            O_sections.push(s)
-            id++
-        }
+  O_sections = [];
+  var x1, y1, x2, y2, x3, y3, x4, y4, id;
+  id = 0;
+  for (var i = 0; i < O_nbsectionshorizontal; i++) {
+    for (var j = 0; j < O_nbsectionsvertical; j++) {
+      if (i == 0) {
+        y4 = random(O_sectionheight * 0.1, O_sectionheight * 0.9);
+      } else {
+        y4 = O_sections[(i - 1) * O_nbsectionsvertical + j].y2;
+      }
+      if (j == 0) {
+        x1 = random(O_sectionwidth * 0.1, O_sectionwidth * 0.9);
+      } else {
+        x1 = O_sections[i * O_nbsectionsvertical + (j - 1)].x3;
+      }
+      var s = {
+        x: i * O_sectionwidth,
+        y: j * O_sectionheight,
+        x1: x1,
+        y1: 0,
+        x2: O_sectionwidth,
+        y2: random(O_sectionheight * 0.1, O_sectionheight * 0.9),
+        x3: random(O_sectionwidth * 0.1, O_sectionwidth * 0.9),
+        y3: O_sectionheight,
+        x4: 0,
+        y4: y4,
+        id: id,
+      };
+      O_sections.push(s);
+      id++;
     }
+  }
 }
 
-var index = 0
-
+var index = 0;
 
 function draw() {
-    var functionName, fn
-    if (O_counter == Object.keys(O_configurationexquise).length * O_sectionduration) {
-        //background(0, 0, 0)
-        noLoop()
-        O_counter = 0
-        index = 0
+  var functionName, fn;
+  if (
+    O_counter ==
+    Object.keys(O_configurationexquise).length * O_sectionduration
+  ) {
+    //background(0, 0, 0)
+    noLoop();
+    O_counter = 0;
+    index = 0;
+  } else {
+    if (O_counter % O_sectionduration == 0) {
+      O_currentsection = O_sections[index];
+      functionName = O_configurationexquise[index].art_set;
+      fn = new Function(`return ${functionName}()`);
+      fn();
+      index++;
     }
-    else {
-        if (O_counter % O_sectionduration == 0) {
-            O_currentsection = O_sections[index]
-            functionName = O_configurationexquise[index].art_set;
-            fn = new Function(`return ${functionName}()`);
-            fn();
-            index++
-        }
-        if (O_counter % O_sectionduration > 0) {
-            functionName = O_configurationexquise[index - 1].art_gen;
-            fn = new Function(`return ${functionName}()`);
-            fn();
-        }
-        O_counter++
+    if (O_counter % O_sectionduration > 0) {
+      functionName = O_configurationexquise[index - 1].art_gen;
+      fn = new Function(`return ${functionName}()`);
+      fn();
     }
+    O_counter++;
+  }
 }
 
-
 function shuffle(array) {
-    let currentIndex = array.length;
+  let currentIndex = array.length;
 
-    // While there remain elements to shuffle...
-    while (currentIndex != 0) {
+  // While there remain elements to shuffle...
+  while (currentIndex != 0) {
+    // Pick a remaining element...
+    let randomIndex = Math.floor(Math.random() * currentIndex);
+    currentIndex--;
 
-        // Pick a remaining element...
-        let randomIndex = Math.floor(Math.random() * currentIndex);
-        currentIndex--;
-
-        // And swap it with the current element.
-        [array[currentIndex], array[randomIndex]] = [
-            array[randomIndex], array[currentIndex]];
-    }
+    // And swap it with the current element.
+    [array[currentIndex], array[randomIndex]] = [
+      array[randomIndex],
+      array[currentIndex],
+    ];
+  }
 }

--- a/exquis-bac-a-sable/exquisite-conductor.js
+++ b/exquis-bac-a-sable/exquisite-conductor.js
@@ -95,15 +95,13 @@ function draw() {
   } else {
     if (O_counter % O_sectionduration == 0) {
       O_currentsection = O_sections[index];
-      functionName = O_configurationexquise[index].art_set;
-      fn = new Function(`return ${functionName}()`);
-      fn();
+      artCode = O_configurationexquise[index].art_code.replace(".js", "");
+      artObject = window[artCode]["init"]();
       index++;
     }
     if (O_counter % O_sectionduration > 0) {
-      functionName = O_configurationexquise[index - 1].art_gen;
-      fn = new Function(`return ${functionName}()`);
-      fn();
+      artCode = O_configurationexquise[index - 1].art_code.replace(".js", "");
+      artObject = window[artCode]["draw"]();
     }
     O_counter++;
   }

--- a/exquis-bac-a-sable/exquisite-conductor.js
+++ b/exquis-bac-a-sable/exquisite-conductor.js
@@ -23,8 +23,10 @@ function setup() {
   O_widthexquis = Math.floor(windowWidth * 0.8);
   O_heightexquis = Math.floor(O_widthexquis / 1.82);
   O_canvas = createCanvas(O_widthexquis, O_heightexquis);
-  O_nbsectionshorizontal = 1;
-  O_nbsectionsvertical = 2;
+  O_nbsectionsvertical = 3;
+  O_nbsectionshorizontal = Math.ceil(
+    Object.keys(O_configurationexquise).length / O_nbsectionsvertical,
+  );
   O_sectionduration = 60 * 2;
 
   // center the canvas

--- a/exquis-bac-a-sable/exquisite-conductor.js
+++ b/exquis-bac-a-sable/exquisite-conductor.js
@@ -1,4 +1,4 @@
-//global variable only used here in the orchestrator sketch
+// Global variable only used here in the orchestrator sketch
 var O_widthexquis,
   O_heightexquis,
   O_canvas,
@@ -6,62 +6,90 @@ var O_widthexquis,
   O_sections,
   O_nbsectionshorizontal,
   O_nbsectionsvertical,
-  O_configurationexquise;
-//global variables that can be used in all sketches
-var O_sectionwidth; //width of a section
-var O_sectionheight; //height of a section
-var O_sectionduration; //duration (in frames) for one section animation
-var O_currentsection; //object that has data for the section that is currently drawing
-var O_counter = 0; //global frame counter
+  O_configurationexquise,
+  O_nbartworks;
 
-function preload() {
-  O_policeexquise = loadFont("./FreeMono.otf");
-  O_configurationexquise = loadJSON("./exquisite.json");
-}
+// Global variables that can be used in all sketches
+var O_sectionwidth; // Width of a section
+var O_sectionheight; // Height of a section
+var O_sectionduration; // Duration (in frames) for one section animation
+var O_currentsection; // Object that has data for the section that is currently drawing
+var O_counter = 0; // Global frame counter
 
-function setup() {
+async function setup() {
+  // Load the font and the configuration file
+  O_policeexquise = await loadFont("./FreeMono.otf");
+  O_configurationexquise = await loadJSON("./exquisite.json");
+
+  // Get the number of artworks
+  O_nbartworks = Object.keys(O_configurationexquise).length;
+
+  // Create the canvas
   O_widthexquis = Math.floor(windowWidth * 0.8);
   O_heightexquis = Math.floor(O_widthexquis / 1.82);
   O_canvas = createCanvas(O_widthexquis, O_heightexquis);
-  O_nbsectionsvertical = 3;
-  O_nbsectionshorizontal = Math.ceil(
-    Object.keys(O_configurationexquise).length / O_nbsectionsvertical,
-  );
-  O_sectionduration = 60 * 2;
 
-  // center the canvas
-  var x = (windowWidth - O_widthexquis) / 2;
-  var y = (windowHeight - O_heightexquis) / 2;
+  // Center the canvas
+  let x = (windowWidth - O_widthexquis) / 2;
+  let y = (windowHeight - O_heightexquis) / 2;
   O_canvas.position(x, y);
   colorMode(HSB, 360, 100, 100, 250);
 
-  // initialize all sections and shuffle their order
+  // Set the duration of a section
+  O_sectionduration = 60 * 2;
+
+  // Compute the number of sections their size
+  O_nbsectionsvertical = 3;
+  O_nbsectionshorizontal = Math.ceil(O_nbartworks / O_nbsectionsvertical);
   O_sectionwidth = Math.floor(O_widthexquis / O_nbsectionshorizontal);
   O_sectionheight = Math.floor(O_heightexquis / O_nbsectionsvertical);
+
+  // Initialize all sections and shuffle them
   initsections();
   O_sections = shuffle(O_sections);
+
+  // Initialize drawing parameters
   textSize(84);
   textFont(O_policeexquise);
   stroke(0, 0, 100);
+
+  // Initialize the artworks
+  let promises = [];
+  for (let i = 0; i < O_nbartworks; i++) {
+    // Initialize all sketches
+    O_currentsection = O_sections[i];
+    let artCode = O_configurationexquise[i].art_code;
+    let promise = window[artCode]["init"]();
+    promises.push(promise);
+  }
+  await Promise.all(promises);
 }
 
 function initsections() {
+  // Initialize some variables
   O_sections = [];
-  var x1, y1, x2, y2, x3, y3, x4, y4, id;
+  let x1, y4, id;
   id = 0;
-  for (var i = 0; i < O_nbsectionshorizontal; i++) {
-    for (var j = 0; j < O_nbsectionsvertical; j++) {
+
+  // Create all sections
+  for (let i = 0; i < O_nbsectionshorizontal; i++) {
+    for (let j = 0; j < O_nbsectionsvertical; j++) {
+      // Check if we are at the beginning of a row
       if (i == 0) {
         y4 = random(O_sectionheight * 0.1, O_sectionheight * 0.9);
       } else {
         y4 = O_sections[(i - 1) * O_nbsectionsvertical + j].y2;
       }
+
+      // Check if we are at the beginning of a column
       if (j == 0) {
         x1 = random(O_sectionwidth * 0.1, O_sectionwidth * 0.9);
       } else {
         x1 = O_sections[i * O_nbsectionsvertical + (j - 1)].x3;
       }
-      var s = {
+
+      // Create the section
+      let section = {
         x: i * O_sectionwidth,
         y: j * O_sectionheight,
         x1: x1,
@@ -74,52 +102,34 @@ function initsections() {
         y4: y4,
         id: id,
       };
-      O_sections.push(s);
+
+      // Add the section to the list and increment the id
+      O_sections.push(section);
       id++;
     }
   }
 }
 
-var index = 0;
-
-async function draw() {
-  var functionName, fn;
-  if (
-    O_counter ==
-    Object.keys(O_configurationexquise).length * O_sectionduration
-  ) {
+let index = 0;
+function draw() {
+  // Check if we are done with all the artworks
+  if (O_counter == O_nbartworks * O_sectionduration) {
     //background(0, 0, 0)
     noLoop();
     O_counter = 0;
     index = 0;
-  } else {
-    if (O_counter % O_sectionduration == 0) {
-      O_currentsection = O_sections[index];
-      artCode = O_configurationexquise[index].art_code;
-      await window[artCode]["init"]();
-      index++;
-    }
-    if (O_counter % O_sectionduration > 0) {
-      artCode = O_configurationexquise[index - 1].art_code;
-      await window[artCode]["draw"]();
-    }
-    O_counter++;
+    return;
   }
-}
 
-function shuffle(array) {
-  let currentIndex = array.length;
-
-  // While there remain elements to shuffle...
-  while (currentIndex != 0) {
-    // Pick a remaining element...
-    let randomIndex = Math.floor(Math.random() * currentIndex);
-    currentIndex--;
-
-    // And swap it with the current element.
-    [array[currentIndex], array[randomIndex]] = [
-      array[randomIndex],
-      array[currentIndex],
-    ];
+  // Check if we need to initialize a new section
+  if (O_counter % O_sectionduration == 0) {
+    index++;
   }
+
+  // Draw the current section
+  if (O_counter % O_sectionduration > 0) {
+    let artCode = O_configurationexquise[index - 1].art_code;
+    window[artCode]["draw"]();
+  }
+  O_counter++;
 }

--- a/exquis-bac-a-sable/exquisite-conductor.js
+++ b/exquis-bac-a-sable/exquisite-conductor.js
@@ -82,7 +82,7 @@ function initsections() {
 
 var index = 0;
 
-function draw() {
+async function draw() {
   var functionName, fn;
   if (
     O_counter ==
@@ -96,12 +96,12 @@ function draw() {
     if (O_counter % O_sectionduration == 0) {
       O_currentsection = O_sections[index];
       artCode = O_configurationexquise[index].art_code;
-      artObject = window[artCode]["init"]();
+      await window[artCode]["init"]();
       index++;
     }
     if (O_counter % O_sectionduration > 0) {
       artCode = O_configurationexquise[index - 1].art_code;
-      artObject = window[artCode]["draw"]();
+      await window[artCode]["draw"]();
     }
     O_counter++;
   }

--- a/exquis-bac-a-sable/exquisite-conductor.js
+++ b/exquis-bac-a-sable/exquisite-conductor.js
@@ -95,12 +95,12 @@ function draw() {
   } else {
     if (O_counter % O_sectionduration == 0) {
       O_currentsection = O_sections[index];
-      artCode = O_configurationexquise[index].art_code.replace(".js", "");
+      artCode = O_configurationexquise[index].art_code;
       artObject = window[artCode]["init"]();
       index++;
     }
     if (O_counter % O_sectionduration > 0) {
-      artCode = O_configurationexquise[index - 1].art_code.replace(".js", "");
+      artCode = O_configurationexquise[index - 1].art_code;
       artObject = window[artCode]["draw"]();
     }
     O_counter++;

--- a/exquis-bac-a-sable/exquisite.json
+++ b/exquis-bac-a-sable/exquisite.json
@@ -1,12 +1,13 @@
 [
-    {
-        "art_code":"exquisitebw.js",
-        "art_set":"initbw",
-        "art_gen":"drawbw"
-    },
-    {
-        "art_code":"exquisitered.js",
-        "art_set":"initred",
-        "art_gen":"drawred"
-    }
+  {
+    "art_code": "exquisitebw.js",
+    "art_set": "initbw",
+    "art_gen": "drawbw"
+  },
+  {
+    "art_code": "exquisitered.js",
+    "art_set": "initred",
+    "art_gen": "drawred"
+  }
 ]
+

--- a/exquis-bac-a-sable/exquisite.json
+++ b/exquis-bac-a-sable/exquisite.json
@@ -1,13 +1,8 @@
 [
   {
-    "art_code": "exquisitebw.js",
-    "art_set": "initbw",
-    "art_gen": "drawbw"
+    "art_code": "exquisitebw.js"
   },
   {
-    "art_code": "exquisitered.js",
-    "art_set": "initred",
-    "art_gen": "drawred"
+    "art_code": "exquisitered.js"
   }
 ]
-

--- a/exquis-bac-a-sable/exquisite.json
+++ b/exquis-bac-a-sable/exquisite.json
@@ -1,8 +1,8 @@
 [
   {
-    "art_code": "exquisitebw.js"
+    "art_code": "exquisitebw"
   },
   {
-    "art_code": "exquisitered.js"
+    "art_code": "exquisitered"
   }
 ]

--- a/exquis-bac-a-sable/exquisitebw.js
+++ b/exquis-bac-a-sable/exquisitebw.js
@@ -1,7 +1,7 @@
 (() => {
   let s, r, rinc;
 
-  function init() {
+  async function init() {
     s = O_currentsection;
     r = 7;
     rinc = 0.5;

--- a/exquis-bac-a-sable/exquisitebw.js
+++ b/exquis-bac-a-sable/exquisitebw.js
@@ -1,22 +1,26 @@
-var s, r, rinc;
+(() => {
+  let s, r, rinc;
 
-function initbw() {
-  s = O_currentsection;
-  r = 7;
-  rinc = 0.5;
-}
+  function init() {
+    s = O_currentsection;
+    r = 7;
+    rinc = 0.5;
+  }
 
-function drawbw() {
-  push();
-  translate(s.x, s.y);
-  fill(0, 0, 0);
-  rect(0, 0, O_sectionwidth, O_sectionheight);
-  fill(0, 0, 100);
-  noStroke();
-  arc(s.x1, s.y1, r, r, 0, PI);
-  arc(s.x2, s.y2, r, r, PI * 0.5, PI * 1.5);
-  arc(s.x3, s.y3, r, r, PI, 2 * PI);
-  arc(s.x4, s.y4, r, r, PI * 1.5, PI * 0.5);
-  pop();
-  r += rinc;
-}
+  function draw() {
+    push();
+    translate(s.x, s.y);
+    fill(0, 0, 0);
+    rect(0, 0, O_sectionwidth, O_sectionheight);
+    fill(0, 0, 100);
+    noStroke();
+    arc(s.x1, s.y1, r, r, 0, PI);
+    arc(s.x2, s.y2, r, r, PI * 0.5, PI * 1.5);
+    arc(s.x3, s.y3, r, r, PI, 2 * PI);
+    arc(s.x4, s.y4, r, r, PI * 1.5, PI * 0.5);
+    pop();
+    r += rinc;
+  }
+
+  window.exquisitebw = { init, draw };
+})();

--- a/exquis-bac-a-sable/exquisitebw.js
+++ b/exquis-bac-a-sable/exquisitebw.js
@@ -22,5 +22,6 @@
     r += rinc;
   }
 
+  // Use the name of the current js file (without the extension) as the key in the object window.
   window.exquisitebw = { init, draw };
 })();

--- a/exquis-bac-a-sable/exquisitebw.js
+++ b/exquis-bac-a-sable/exquisitebw.js
@@ -8,18 +8,25 @@
   }
 
   function draw() {
+    // Move to the section
     push();
     translate(s.x, s.y);
+
+    // Create border around section
     fill(0, 0, 0);
     rect(0, 0, O_sectionwidth, O_sectionheight);
     fill(0, 0, 100);
     noStroke();
+
+    // Draw our art
     arc(s.x1, s.y1, r, r, 0, PI);
     arc(s.x2, s.y2, r, r, PI * 0.5, PI * 1.5);
     arc(s.x3, s.y3, r, r, PI, 2 * PI);
     arc(s.x4, s.y4, r, r, PI * 1.5, PI * 0.5);
-    pop();
     r += rinc;
+
+    // Pop out of the section
+    pop();
   }
 
   // Use the name of the current js file (without the extension) as the key in the object window.

--- a/exquis-bac-a-sable/exquisitebw.js
+++ b/exquis-bac-a-sable/exquisitebw.js
@@ -1,23 +1,22 @@
-var s,r,rinc
+var s, r, rinc;
 
 function initbw() {
-    s = O_currentsection
-    r=7
-    rinc=0.5
+  s = O_currentsection;
+  r = 7;
+  rinc = 0.5;
 }
 
-
 function drawbw() {
-    push()
-    translate(s.x, s.y)
-    fill(0,0,0)
-    rect(0,0,O_sectionwidth,O_sectionheight)
-    fill(0,0,100)
-    noStroke()
-    arc(s.x1,s.y1,r,r,0,PI)
-    arc(s.x2,s.y2,r,r,PI*0.5,PI*1.5)
-    arc(s.x3,s.y3,r,r,PI,2*PI)
-    arc(s.x4,s.y4,r,r,PI*1.5,PI*0.5)
-    pop()
-    r+=rinc
+  push();
+  translate(s.x, s.y);
+  fill(0, 0, 0);
+  rect(0, 0, O_sectionwidth, O_sectionheight);
+  fill(0, 0, 100);
+  noStroke();
+  arc(s.x1, s.y1, r, r, 0, PI);
+  arc(s.x2, s.y2, r, r, PI * 0.5, PI * 1.5);
+  arc(s.x3, s.y3, r, r, PI, 2 * PI);
+  arc(s.x4, s.y4, r, r, PI * 1.5, PI * 0.5);
+  pop();
+  r += rinc;
 }

--- a/exquis-bac-a-sable/exquisitered.js
+++ b/exquis-bac-a-sable/exquisitered.js
@@ -1,7 +1,7 @@
 (() => {
   let s;
 
-  function init() {
+  async function init() {
     s = O_currentsection;
   }
 

--- a/exquis-bac-a-sable/exquisitered.js
+++ b/exquis-bac-a-sable/exquisitered.js
@@ -1,26 +1,30 @@
-var s;
+(() => {
+  let s;
 
-function initred() {
-  s = O_currentsection;
-}
-
-function drawred() {
-  var r = random();
-  push();
-  translate(s.x, s.y);
-  if (r > 0.42) {
-    fill(0, 100, 100);
-    noStroke();
-    quad(s.x1, s.y1, s.x2, s.y2, s.x3, s.y3, s.x4, s.y4);
-  } else {
-    fill(0, 0, 0);
-    rect(0, 0, O_sectionwidth, O_sectionheight);
-  }
-  if (O_counter % O_sectionduration == O_sectionduration - 1) {
-    fill(0, 100, 100);
-    noStroke();
-    quad(s.x1, s.y1, s.x2, s.y2, s.x3, s.y3, s.x4, s.y4);
+  function init() {
+    s = O_currentsection;
   }
 
-  pop();
-}
+  function draw() {
+    let r = random();
+    push();
+    translate(s.x, s.y);
+    if (r > 0.42) {
+      fill(0, 100, 100);
+      noStroke();
+      quad(s.x1, s.y1, s.x2, s.y2, s.x3, s.y3, s.x4, s.y4);
+    } else {
+      fill(0, 0, 0);
+      rect(0, 0, O_sectionwidth, O_sectionheight);
+    }
+    if (O_counter % O_sectionduration == O_sectionduration - 1) {
+      fill(0, 100, 100);
+      noStroke();
+      quad(s.x1, s.y1, s.x2, s.y2, s.x3, s.y3, s.x4, s.y4);
+    }
+
+    pop();
+  }
+
+  window.exquisitered = { init, draw };
+})();

--- a/exquis-bac-a-sable/exquisitered.js
+++ b/exquis-bac-a-sable/exquisitered.js
@@ -1,28 +1,26 @@
-var s
+var s;
 
 function initred() {
-    s = O_currentsection
+  s = O_currentsection;
 }
 
-
 function drawred() {
-    var r=random()
-    push()
-    translate(s.x, s.y)
-    if(r>0.42){
-        fill(0,100,100)
-        noStroke()
-        quad(s.x1,s.y1,s.x2,s.y2,s.x3,s.y3,s.x4,s.y4)
-    }
-    else{
-        fill(0,0,0)
-        rect(0,0,O_sectionwidth,O_sectionheight)
-    }
-    if(O_counter%O_sectionduration==O_sectionduration-1){
-        fill(0,100,100)
-        noStroke()
-        quad(s.x1,s.y1,s.x2,s.y2,s.x3,s.y3,s.x4,s.y4)
-    }
+  var r = random();
+  push();
+  translate(s.x, s.y);
+  if (r > 0.42) {
+    fill(0, 100, 100);
+    noStroke();
+    quad(s.x1, s.y1, s.x2, s.y2, s.x3, s.y3, s.x4, s.y4);
+  } else {
+    fill(0, 0, 0);
+    rect(0, 0, O_sectionwidth, O_sectionheight);
+  }
+  if (O_counter % O_sectionduration == O_sectionduration - 1) {
+    fill(0, 100, 100);
+    noStroke();
+    quad(s.x1, s.y1, s.x2, s.y2, s.x3, s.y3, s.x4, s.y4);
+  }
 
-    pop()
+  pop();
 }

--- a/exquis-bac-a-sable/exquisitered.js
+++ b/exquis-bac-a-sable/exquisitered.js
@@ -7,8 +7,12 @@
 
   function draw() {
     let r = random();
+
+    // Move to the section
     push();
     translate(s.x, s.y);
+
+    // Draw our art
     if (r > 0.42) {
       fill(0, 100, 100);
       noStroke();
@@ -23,6 +27,7 @@
       quad(s.x1, s.y1, s.x2, s.y2, s.x3, s.y3, s.x4, s.y4);
     }
 
+    // Pop out of the section
     pop();
   }
 

--- a/exquis-bac-a-sable/exquisitered.js
+++ b/exquis-bac-a-sable/exquisitered.js
@@ -26,5 +26,6 @@
     pop();
   }
 
+  // Use the name of the current js file (without the extension) as the key in the object window.
   window.exquisitered = { init, draw };
 })();

--- a/exquis-bac-a-sable/readme.md
+++ b/exquis-bac-a-sable/readme.md
@@ -4,20 +4,18 @@ This folder includes a sandbox to experiment with two gen art pieces to be inclu
 
 To design, experiment and tune your own artworks:
 
-- ```exquisite-conductor.html```: nothing to change
-- ```exquisite-conductor.js```: nothing to change
-- ```exquisitebw.js```,```exquisitered.js```: they are examples of code structures. You must no reuse them. Write your own two artworks.
-- ```exquisite.json```: replace by the name of your own artworks: the name of the code file for the artwork ("art_code"), the name of the function that initializes the artwork ("art_set") and the name of the function that actually generates the artwork ("art_gen")
+- `exquisite-conductor.html`: Nothing to change.
+- `exquisite-conductor.js`: Nothing to change.
+- `exquisitebw.js`,`exquisitered.js`: They are examples of code structures. You must no reuse them. Write your own two artworks.
+- `exquisite.json`: Add your own artworks. The `art_code` key should be the name of your js file **without** the extension.
 - Global variables to use:
-  - ```O_currentsection```: the object that has all data for the section in which you draw your artwork
-  - ```O_sectionduration```: the duration during which your artwork draws
-  - ```O_sectionheight```: height of the section in which you draw
-  - ```O_sectionwidth```: width of the section in which you draw
-  - a section object has different fields
-    - ```x```, ```y```: the coordinates of the top left corner for the section
-    - ```x1```, ```y1```: a point on the top edge of section (to anchor with the artwork on top of yous)
-    - ```x2```, ```y2```: a point on the right edge of section (to anchor with the artwork on right of yous)
-    - ```x3```, ```y3```: a point on the bottom edge of section (to anchor with the artwork on bottom of yous)
-    - ```x4```, ```y4```: a point on the left edge of section (to anchor with the artwork on left of yous)
-    - ```id```: a unique id (between 0 and 26) for your section
- 
+  - `O_currentsection`: The object that has all data for the section in which you draw your artwork. A section object has different fields
+    - `x`, `y`: The coordinates of the top left corner for the section.
+    - `x1`, `y1`: A point on the top edge of section (to anchor with the artwork on top of yours).
+    - `x2`, `y2`: A point on the right edge of section (to anchor with the artwork on right of yours).
+    - `x3`, `y3`: A point on the bottom edge of section (to anchor with the artwork on bottom of yours).
+    - `x4`, `y4`: A point on the left edge of section (to anchor with the artwork on left of yours).
+    - `id`: A unique id (between 0 and 26) for your section.
+  - `O_sectionduration`: The duration during which your artwork draws.
+  - `O_sectionheight`: Height of the section in which you draw.
+  - `O_sectionwidth`: Width of the section in which you draw.


### PR DESCRIPTION
# Changes

- Because of the way each artwork is imported, they all shared the same scope which caused issues with global variables. That was fixed.
- Each artwork is now imported as a module. This allows imports in them.
- Simplified the JS format to only use the file name.
  - Each artwork returns an object containing an `init` and `draw` function. These are stored in an object. The field of the object is the file name of the artwork.
- The number of tiles is now dynamic and assumes 3 rows of art.
  - This issue made the code crash when there were more than 2 artworks.
- `README` was updated accordingly
- Moved to p5js `2.0.0 beta 4` as it allows an async `setup()` function. This is useful as it allows initializing the `init()` function of artworks in parallel and allows users to use async functions in their `init()` code.